### PR TITLE
Added libappindicator-gtk3 as a dependency

### DIFF
--- a/discord.spec
+++ b/discord.spec
@@ -27,6 +27,7 @@ Requires:       libXtst%{_isa} >= 1.2
 Requires:       libappindicator%{_isa}
 Requires:       libcxx%{_isa}
 Requires:       libatomic%{_isa}
+Requires:       libappindicator-gtk3%{_isa}
 
 Recommends:     google-noto-emoji-color-fonts
 


### PR DESCRIPTION
For the latest version of gnome i.e 3.38 all electron apps need libappindicator-gtk3 for the appindicator to work.