### PR TITLE
Update the app summary/description to match the application’s current status

### DIFF
--- a/discord.spec
+++ b/discord.spec
@@ -8,7 +8,7 @@
 Name:           discord
 Version:        0.0.34
 Release:        1%{?dist}
-Summary:        All-in-one voice and text chat for gamers
+Summary:        All-in-one voice and text chat
 
 # License Information: https://bugzilla.rpmfusion.org/show_bug.cgi?id=4441#c14
 License:        Proprietary
@@ -41,8 +41,7 @@ Recommends:     libXScrnSaver
 %endif
 
 %description
-Linux Release for Discord, a free proprietary VoIP application designed for
-gaming communities.
+Linux Release for Discord, a free proprietary VoIP application
 
 %prep
 %autosetup -n Discord


### PR DESCRIPTION
This change removes references to gaming from the summary and description. This  
is to reflect the application’s current general-purpose branding and status.

As of [June 2020][1], Discord is no longer marketed nor developed as a gaming-first chat  
application: The software is now branded as a general purpose chat app for everyone,  
and they've been promoting their featureset for a more general audience (even before  
the branding change), such as [for][2] [education][3].

---

This change was originally brought up [on Bugzilla][4]. I was asked to create a pull request  
here for the change.

[1]: https://discord.com/blog/your-place-to-talk
[2]: https://discord.com/blog/best-discord-apps-for-students-studying-socializing
[3]: https://discord.com/blog/eight-educational-communities-to-further-your-field-of-study
[4]: https://bugzilla.rpmfusion.org/show_bug.cgi?id=6147