### PR TITLE
Bugfix : disable discord check update pop-up

### DIFF
--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Disable breaking updates which will prompt users to download a deb or tar file
+and lock them out of Discord making the program unusable.
+
+This will dramatically improve the experience :
+
+ 1) The maintainer doesn't need to be worried at all times of an update which will break Discord.
+ 2) People will not be locked out of the program while the maintainer runs to update it.
+
+"""
+
+import json
+import os
+from pathlib import Path
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+settings_path = Path(f"{XDG_CONFIG_HOME}/discord/settings.json")
+settings_path_temp = Path(f"{XDG_CONFIG_HOME}/discord/settings.json.tmp")
+try:
+    with settings_path.open() as settings_file:
+        settings = json.load(settings_file)
+except (IOError, json.decoder.JSONDecodeError):
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings = {}
+
+if settings.get("SKIP_HOST_UPDATE"):
+    print("Disabling updates already done")
+else:
+    skip_host_update = {"SKIP_HOST_UPDATE":True}
+    settings.update(skip_host_update)
+
+    with settings_path_temp.open('w') as settings_file_temp:
+        json.dump(settings, settings_file_temp, indent=2)
+
+    settings_path_temp.rename(settings_path)
+    print("Disabled updates")

--- a/disable-breaking-updates.py
+++ b/disable-breaking-updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """
 Disable breaking updates which will prompt users to download a deb or tar file
 and lock them out of Discord making the program unusable.

--- a/discord.spec
+++ b/discord.spec
@@ -16,6 +16,8 @@ URL:            https://discordapp.com/
 Source0:        https://dl.discordapp.net/apps/linux/%{version}/%{name}-%{version}.tar.gz
 # Adapted from https://raw.githubusercontent.com/flathub/com.discordapp.Discord/master/com.discordapp.Discord.appdata.xml
 Source1:        discord.metainfo.xml
+Source2:        wrapper.sh
+Source3:        disable-breaking-updates.py
 ExclusiveArch:  x86_64
 
 BuildRequires:  desktop-file-utils
@@ -32,6 +34,7 @@ Requires:       libXtst%{_isa} >= 1.2
 Requires:       libappindicator%{_isa}
 Requires:       libcxx%{_isa}
 Requires:       libatomic%{_isa}
+Requires:       python3%{_isa}
 Requires:       hicolor-icon-theme
 
 %if !0%{?el7}
@@ -56,7 +59,7 @@ mkdir -p %{buildroot}%{_metainfodir}/
 
 desktop-file-install                            \
 --set-icon=%{name}                              \
---set-key=Exec --set-value=%{_bindir}/Discord   \
+--set-key=Exec --set-value='%{_bindir}/bash %{_libdir}/discord/wrapper.sh' \
 --delete-original                               \
 --dir=%{buildroot}/%{_datadir}/applications     \
 discord.desktop
@@ -67,6 +70,8 @@ install -p -D -m 644 %{name}.png \
         %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/%{name}.png
 
 install -p -m 0644 %{SOURCE1} %{buildroot}%{_metainfodir}/
+install -p -m 755 %{SOURCE2} %{buildroot}%{_libdir}/discord/
+install -p -m 755 %{SOURCE3} %{buildroot}%{_libdir}/discord/
 
 %check
 desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop

--- a/discord.spec
+++ b/discord.spec
@@ -34,7 +34,6 @@ Requires:       libXtst%{_isa} >= 1.2
 Requires:       libappindicator%{_isa}
 Requires:       libcxx%{_isa}
 Requires:       libatomic%{_isa}
-Requires:       python3%{_isa}
 Requires:       hicolor-icon-theme
 
 %if !0%{?el7}

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Path to discord binary 
+DISCORD_BIN=/usr/bin/Discord
+
+# Run python script to disable check updates
+/usr/lib64/discord/disable-breaking-updates.py
+
+# Launch discord 
+exec "$DISCORD_BIN"


### PR DESCRIPTION
Hi,

On @kwizart's recommendation, I've reviewed my previous solution proposal about disabling discord search updates at startup.

So I applied the advice to run the disable check update script via a wrapper to the discord binary.

As regards the script I had initially proposed, it didn't cover all the use cases, so I looked for what the flatpak application proposed on this subject and I found a python script designed for this purpose and more robust than my script, so I integrated it into the solution so that it would be executed by the wrapper when the application was started.

I tested a rebuild of the application on my side with these modifications and it worked perfectly (first installation or update).